### PR TITLE
Pin core-js@2.6.1 to fix npm-based install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mdx-js/mdx": "0.15.x",
     "@mdx-js/tag": "0.15.x",
     "babel-plugin-styled-components": "^1.10.0",
+    "core-js": "^2.6.1",
     "gatsby": "^2.0.76",
     "gatsby-image": "^2.0.25",
     "gatsby-mdx": "^0.2.0",


### PR DESCRIPTION
I tried running `npm run dev` in a fresh install of the emilia starter on a system without yarn installed, and the command fails with this error:

```
success onPostBootstrap — 0.228 s
error Cannot find module 'core-js/modules/es6.regexp.to-string'
```

Running `npm install --save-prod core-js@2.6.1` seems to fix it. After doing that `npm run dev` with yarn installed still seems to succeed as well.

Looks like this same issue has popped up in other gatsby starters; so I basically borrowed one of their fixes:

https://github.com/maxpou/gatsby-starter-morning-dew/pull/29